### PR TITLE
Update call_thug.py

### DIFF
--- a/args.py
+++ b/args.py
@@ -188,6 +188,15 @@ debug mode)')
     thug.add_argument('-T', '--timeout',
                         metavar='',
                         help='Timeout in minutes')
+    thug.add_argument('-Z', '--json-logging',
+                        action='store_true',
+                        help='Enable JSON logging mode')
+    thug.add_argument('-F', '--file-logging',
+                        action='store_true',
+                        help='Enable file logging mode')
+    thug.add_argument('-y', '--vtquery',
+                        action='store_true',
+                        help='Query VirusTotal for samples analysis')
 
     # Plugins
     plugin = parser.add_argument_group('Plugins')

--- a/call_thug.py
+++ b/call_thug.py
@@ -27,11 +27,12 @@ from Plugins.ThugPlugins import *
 log = logging.getLogger("Thug")
 log.setLevel(logging.WARN)
 
+configuration_path = "/etc/thug"
 
 class Thug(ThugAPI):
     def __init__(self, url):
         # args(url) not used in ThugAPI code so just passed URL
-        ThugAPI.__init__(self, url)
+        ThugAPI.__init__(self, url, configuration_path)
 
     def analyze(self, opts):
         p = getattr(self, 'run_remote', None)

--- a/call_thug.py
+++ b/call_thug.py
@@ -90,6 +90,12 @@ class Thug(ThugAPI):
         if options['jsclassifier']:
             for classifier in options['jsclassifier'].split(','):
                 self.add_jsclassifier(os.path.abspath(classifier))
+        if options['json_logging']:
+            self.set_json_logging()
+        if options['file_logging']:
+            self.set_file_logging()
+        if options['vtquery']:
+            self.set_vt_query()
 
         self.log_init(self.args)
 


### PR DESCRIPTION
If you don't specify a configuration path for thug configuration files thugd failes because it can't find personalities.  ThugAPI by default looks for configuration_path but if that doesn't exist DOM/Personalities.py looks for the personalities directory in lib/python2.7/dist-packages/thug*/DOM.  Thug installation puts config files in /etc/thug.

[2015-12-03 15:22:30,450: WARNING/Worker-4] [CRITICAL] Thug personalities not found! Exiting                                                                                   [92/1819]
[2015-12-03 15:22:30,468: ERROR/MainProcess] Task ThugD.thug_instances.thug[e4ec4b5c-3255-4f85-b61c-c6a4a1ce5d49] raised unexpected: WorkerLostError('Worker exited prematurely: exitcod
e 0.',)
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/billiard/pool.py", line 1175, in mark_as_worker_lost
    human_status(exitcode)),
WorkerLostError: Worker exited prematurely: exitcode 0.
